### PR TITLE
Cookie Factory - Json validation and log if null

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -7,6 +7,7 @@ use Elao\Bundle\ConsentBundle\Cookie\CookieFactory;
 use Elao\Bundle\ConsentBundle\EventListener\ConsentEventSubscriber;
 use Elao\Bundle\ConsentBundle\Renderer\ToastRenderer;
 use Elao\Bundle\ConsentBundle\Twig\ConsentExtension;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Asset\Packages;
 
 return function(ContainerConfigurator $configurator) {
@@ -17,6 +18,7 @@ return function(ContainerConfigurator $configurator) {
         ->args([
             '$name' => abstract_arg('cookie.name'),
             '$ttl' => abstract_arg('cookie.ttl'),
+            '$logger' => service(LoggerInterface::class),
         ])
     ;
 

--- a/src/Cookie/CookieFactory.php
+++ b/src/Cookie/CookieFactory.php
@@ -10,6 +10,7 @@
 
 namespace Elao\Bundle\ConsentBundle\Cookie;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -17,11 +18,13 @@ class CookieFactory
 {
     private string $name;
     private int $ttl;
+    private LoggerInterface $logger;
 
-    public function __construct(string $name, int $ttl)
+    public function __construct(string $name, int $ttl, LoggerInterface $logger)
     {
         $this->name = $name;
         $this->ttl = $ttl;
+        $this->logger = $logger;
     }
 
     public function create(array $consents): Cookie
@@ -34,6 +37,16 @@ class CookieFactory
 
     public function read(Request $request): array
     {
-        return json_decode($request->cookies->get($this->name, '[]'), true);
+        $cookieValue = json_decode($request->cookies->get($this->name, '[]'), true);
+
+        if (null === $cookieValue) {
+            $this->logger->warning('Consent Bundle - Decoded cookie value return null', [
+                'Cookie value' => $request->cookies->get($this->name),
+            ]);
+
+            return [];
+        }
+
+        return $cookieValue;
     }
 }


### PR DESCRIPTION
Valider que `json_decode()` du cookie de consentement retourne bien un tableau, sinon logger la valeur et retourner un tableau vide.